### PR TITLE
Log with RandomGame TAG to Avoid Xposed Log Flooding

### DIFF
--- a/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
+++ b/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
@@ -10,6 +10,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.log
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,8 @@ import static de.robv.android.xposed.XposedHelpers.findClass;
 
 
 public class Main implements IXposedHookLoadPackage {
-
+    
+    private static final String TAG = "RandomGame";
     private static final String WECHAT_PACKAGE_NAME = "com.tencent.mm";
 
     private static String wechatVersion = "";

--- a/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
+++ b/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
@@ -108,7 +108,7 @@ public class Main implements IXposedHookLoadPackage {
                 for (ApplicationInfo applicationInfo : applicationList) {
                     String packageName = applicationInfo.packageName;
                     if (isTarget(packageName)) {
-                        log("Hid package: " + packageName);
+                        Log.i(TAG, "Hid package: " + packageName);
                     } else {
                         resultapplicationList.add(applicationInfo);
                     }
@@ -125,7 +125,7 @@ public class Main implements IXposedHookLoadPackage {
                 for (PackageInfo packageInfo : packageInfoList) {
                     String packageName = packageInfo.packageName;
                     if (isTarget(packageName)) {
-                        log("Hid package: " + packageName);
+                        Log.i(TAG, "Hid package: " + packageName);
                     } else {
                         resultpackageInfoList.add(packageInfo);
                     }
@@ -139,7 +139,7 @@ public class Main implements IXposedHookLoadPackage {
                 String packageName = (String) param.args[0];
                 if (isTarget(packageName)) {
                     param.args[0] = WECHAT_PACKAGE_NAME;
-                    log("Fake package: " + packageName + " as " + WECHAT_PACKAGE_NAME);
+                    Log.i(TAG, "Fake package: " + packageName + " as " + WECHAT_PACKAGE_NAME);
                 }
             }
         });
@@ -149,7 +149,7 @@ public class Main implements IXposedHookLoadPackage {
                 String packageName = (String) param.args[0];
                 if (isTarget(packageName)) {
                     param.args[0] = WECHAT_PACKAGE_NAME;
-                    log("Fake package: " + packageName + " as " + WECHAT_PACKAGE_NAME);
+                    Log.i(TAG, "Fake package: " + packageName + " as " + WECHAT_PACKAGE_NAME);
                 }
             }
         });

--- a/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
+++ b/app/src/main/java/me/veryyoung/wechat/randomgame/Main.java
@@ -10,7 +10,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.log
+import android.util.log;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/me/veryyoung/wechat/randomgame/VersionParam.java
+++ b/app/src/main/java/me/veryyoung/wechat/randomgame/VersionParam.java
@@ -8,6 +8,9 @@ public class VersionParam {
 
     public static void init(String version) {
         switch (version) {
+            case "6.3.22":
+                randomGameClass = "com.tencent.mm.sdk.platformtools.be";
+                gameType = "rl";
             case "6.3.23":
             case "6.3.25":
                 randomGameClass = "com.tencent.mm.sdk.platformtools.be";


### PR DESCRIPTION
There is a flood in Xposed log, moving unnecessary logs into logcat.